### PR TITLE
Use canonical language codes during conversion

### DIFF
--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -188,7 +188,8 @@ def extract_book(input_path, encoding):
 
 def convert_item(
         ebook_title, input_path, output_path, source_lang, target_lang,
-        cache_only, is_batch, format, encoding, direction, notification):
+        cache_only, is_batch, format, encoding, direction, target_lang_code,
+        notification):
     """The following parameters need attention:
     :cache_only: Only use the translation which exists in the cache.
     :notification: It is automatically added by arbitrary_n.
@@ -199,8 +200,7 @@ def convert_item(
 
     element_handler = get_element_handler(
         translator.placeholder, translator.separator, direction)
-    element_handler.set_translation_lang(
-        translator.get_iso639_target_code(target_lang))
+    element_handler.set_translation_lang(target_lang_code)
 
     merge_length = str(element_handler.get_merge_length())
     _encoding = ''
@@ -276,7 +276,7 @@ class ConversionWorker:
                 'convert_item',
                 (ebook.title, input_path, output_path, ebook.source_lang,
                  ebook.target_lang, cache_only, is_batch, ebook.input_format,
-                 ebook.encoding, ebook.target_direction)),
+                 ebook.encoding, ebook.target_direction, ebook.lang_code)),
             description=(_('[{} > {}] Translating "{}"').format(
                 ebook.source_lang, ebook.target_lang, ebook.title)))
         self.working_jobs[job] = (ebook, output_path)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -118,6 +118,18 @@ class TestConversionWorker(unittest.TestCase):
         self.assertIs(self.icon, arguments.get('icon'))
 
 class TestLangCodeRegression(unittest.TestCase):
+    def setUp(self):
+        self.gui = Mock()
+        self.icon = Mock()
+        self.worker = ConversionWorker(self.gui, self.icon)
+        self.worker.db = Mock()
+        self.worker.api = Mock()
+
+        self.ebook = Mock(Ebook)
+        self.job = Mock()
+        self.worker.working_jobs = {
+            self.job: (self.ebook, str(Path('/path/to/test.epub')))}
+
     @patch(module_name + '.get_element_handler')
     @patch(module_name + '.get_translation')
     @patch(module_name + '.get_translator')


### PR DESCRIPTION
## Summary
- accept a canonical `target_lang_code` in `convert_item` and apply it directly to element handlers
- pass `ebook.lang_code` when queuing conversion jobs
- keep the project language code fixed after creation instead of updating it when engines or target languages change
- add regression test for exporting translations mixed from engines with different language labels

## Testing
- `pytest -q` *(fails: attempted relative import beyond top-level package; ModuleNotFoundError: No module named 'lxml', 'mechanize')*
- `pip install lxml mechanize` *(fails: Could not find a version that satisfies the requirement lxml)*

------
https://chatgpt.com/codex/tasks/task_e_68bb12e6e4488326ad6f08f404ce4bb8